### PR TITLE
add a comment to the workflow yaml

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -1,5 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# add this line to retrigger actions in transferred repository
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
 to try to trigger actions again in the transferred repository (actions didn't work after transfer)