### PR TITLE
Add the pkgdown as github pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,7 @@
 ^\.github$
 ^doc$
 ^Meta$
+^cran-comments\.md$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,35 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: pkgdown
+          needs: website
+
+      - name: Deploy package
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 inst/doc
 doc
 Meta
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-URL: https://github.com/cellmapslab/longmixr
+URL: https://github.com/cellmapslab/longmixr,
+    https://cellmapslab.github.io/longmixr/
 BugReports: https://github.com/cellmapslab/longmixr/issues
 biocViews:
 Imports: 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ plot shows the average consensus of each subject with all other subjects that
 belong to one cluster. The cluster consensus plot depicts the average consensus
 between all members of each cluster.
 
+The above mentioned plots are generated when calling the `plot` function:
+
 ``` r
 plot(clustering)
 ```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://cellmapslab.github.io/longmixr/
+template:
+  bootstrap: 5
+


### PR DESCRIPTION
I've used usethis::use_pkgdown_github_pages(), however I got an error message in the last step:

Error in gh_process_response(raw) :
GitHub API error (404):
Message: Not Found
Read more at https://docs.github.com/rest/reference/repos#update-a-repository

URL not found: https://api.github.com/repos/cellmapslab/longmixr

I'm not sure why this doesn't work because when using the URL and trying a simple GET request, it works:

gh::gh("GET /repos/cellmapslab/longmixr")

It seems that only the last step - setting the homepage URL - is not done correctly. Therefore, I tried to manually set it in the GUI, but there the URL is already set. Therefore, I try to deploy it anyways.

Also, I minimally changed the README.